### PR TITLE
add Cypress component tests

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,0 +1,7 @@
+{
+  "experimentalComponentTesting": true,
+  "componentFolder": "src",
+  "testFiles": "**/*spec.js",
+  "fixturesFolder": false,
+  "supportFile": false
+}

--- a/cypress/integration/spec.js
+++ b/cypress/integration/spec.js
@@ -1,0 +1,1 @@
+// add end-to-end tests if needed

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -1,0 +1,3 @@
+module.exports = (on) => {
+  on('file:preprocessor', require('@bahmutov/cy-rollup')())
+}

--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -1,29 +1,29 @@
 module.exports = {
-    src_folders: ['test'],
-    output_folder: 'result',
+  src_folders: ['test'],
+  output_folder: 'result',
 
-    webdriver: {
-        start_process: true,
-        server_path: 'node_modules/.bin/chromedriver',
-        port: 9515,
+  webdriver: {
+    start_process: true,
+    server_path: 'node_modules/.bin/chromedriver',
+    port: 9515,
+  },
+
+  test_runner: {
+    type: 'mocha',
+    options: {
+      ui: 'bdd',
+      reporter: 'list',
     },
+  },
 
-    test_runner: {
-        type: 'mocha',
-        options: {
-            ui: 'bdd',
-            reporter: 'list',
+  test_settings: {
+    default: {
+      desiredCapabilities: {
+        browserName: 'chrome',
+        chromeOptions: {
+          args: ['--headless', '--no-sandbox', '--disable-gpu'],
         },
+      },
     },
-
-    test_settings: {
-        default: {
-            desiredCapabilities: {
-                browserName: 'chrome',
-                chromeOptions: {
-                    args: ['--headless', '--no-sandbox', '--disable-gpu'],
-                },
-            },
-        },
-    },
+  },
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-    "name": "svelte-component-library-template",
-    "version": "0.0.1",
+    "name": "@leveluptuts/svelte-notion",
+    "version": "0.0.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -31,6 +31,153 @@
             "dev": true,
             "requires": {
                 "regenerator-runtime": "^0.13.4"
+            }
+        },
+        "@bahmutov/cy-rollup": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@bahmutov/cy-rollup/-/cy-rollup-2.0.0.tgz",
+            "integrity": "sha512-KJlvqB3U1nvKSq7djkXcvM4WpBLP6HEWKKzChI8s/aw0pYm0gVc+sphpyz5CmGpsNE9+/1QB6yoDfTe9Q97SJw==",
+            "dev": true,
+            "requires": {
+                "debug": "4.1.1"
+            }
+        },
+        "@cypress/listr-verbose-renderer": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@cypress/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
+            "integrity": "sha1-p3SS9LEdzHxEajSz4ochr9M8ZCo=",
+            "dev": true,
+            "requires": {
+                "chalk": "^1.1.3",
+                "cli-cursor": "^1.0.2",
+                "date-fns": "^1.27.2",
+                "figures": "^1.7.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
+                    }
+                },
+                "cli-cursor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+                    "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+                    "dev": true,
+                    "requires": {
+                        "restore-cursor": "^1.0.1"
+                    }
+                },
+                "figures": {
+                    "version": "1.7.0",
+                    "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+                    "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+                    "dev": true,
+                    "requires": {
+                        "escape-string-regexp": "^1.0.5",
+                        "object-assign": "^4.1.0"
+                    }
+                },
+                "onetime": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+                    "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+                    "dev": true
+                },
+                "restore-cursor": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+                    "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+                    "dev": true,
+                    "requires": {
+                        "exit-hook": "^1.0.0",
+                        "onetime": "^1.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                }
+            }
+        },
+        "@cypress/request": {
+            "version": "2.88.5",
+            "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.5.tgz",
+            "integrity": "sha512-TzEC1XMi1hJkywWpRfD2clreTa/Z+lOrXDCxxBTBPEcY5azdPi56A6Xw+O4tWJnaJH3iIE7G5aDXZC6JgRZLcA==",
+            "dev": true,
+            "requires": {
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.8.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.2",
+                "har-validator": "~5.1.3",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "~2.5.0",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.3.2"
+            }
+        },
+        "@cypress/xvfb": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@cypress/xvfb/-/xvfb-1.2.4.tgz",
+            "integrity": "sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==",
+            "dev": true,
+            "requires": {
+                "debug": "^3.1.0",
+                "lodash.once": "^4.1.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                }
             }
         },
         "@nodelib/fs.scandir": {
@@ -65,11 +212,48 @@
             "integrity": "sha512-oZLYFEAzUKyi3SKnXvj32ZCEGH6RDnao7COuCVhDydMS9NrCSVXhM79VaKyP5+Zc33m0QXEd2DN3UkU7OsHcfw==",
             "dev": true
         },
+        "@samverschueren/stream-to-observable": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
+            "integrity": "sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
+            "dev": true,
+            "requires": {
+                "any-observable": "^0.3.0"
+            }
+        },
         "@testim/chrome-version": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/@testim/chrome-version/-/chrome-version-1.0.7.tgz",
             "integrity": "sha512-8UT/J+xqCYfn3fKtOznAibsHpiuDshCb0fwgWxRazTT19Igp9ovoXMPhXyLD6m3CKQGTMHgqoxaFfMWaL40Rnw==",
             "dev": true
+        },
+        "@types/blob-util": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/@types/blob-util/-/blob-util-1.3.3.tgz",
+            "integrity": "sha512-4ahcL/QDnpjWA2Qs16ZMQif7HjGP2cw3AGjHabybjw7Vm1EKu+cfQN1D78BaZbS1WJNa1opSMF5HNMztx7lR0w==",
+            "dev": true
+        },
+        "@types/bluebird": {
+            "version": "3.5.29",
+            "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.29.tgz",
+            "integrity": "sha512-kmVtnxTuUuhCET669irqQmPAez4KFnFVKvpleVRyfC3g+SHD1hIkFZcWLim9BVcwUBLO59o8VZE4yGCmTif8Yw==",
+            "dev": true
+        },
+        "@types/chai": {
+            "version": "4.2.7",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.7.tgz",
+            "integrity": "sha512-luq8meHGYwvky0O7u0eQZdA7B4Wd9owUCqvbw2m3XCrCU8mplYOujMBbvyS547AxJkC+pGnd0Cm15eNxEUNU8g==",
+            "dev": true
+        },
+        "@types/chai-jquery": {
+            "version": "1.1.40",
+            "resolved": "https://registry.npmjs.org/@types/chai-jquery/-/chai-jquery-1.1.40.tgz",
+            "integrity": "sha512-mCNEZ3GKP7T7kftKeIs7QmfZZQM7hslGSpYzKbOlR2a2HCFf9ph4nlMRA9UnuOETeOQYJVhJQK7MwGqNZVyUtQ==",
+            "dev": true,
+            "requires": {
+                "@types/chai": "*",
+                "@types/jquery": "*"
+            }
         },
         "@types/color-name": {
             "version": "1.1.1",
@@ -100,10 +284,31 @@
                 "@types/node": "*"
             }
         },
+        "@types/jquery": {
+            "version": "3.3.31",
+            "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.31.tgz",
+            "integrity": "sha512-Lz4BAJihoFw5nRzKvg4nawXPzutkv7wmfQ5121avptaSIXlDNJCUuxZxX/G+9EVidZGuO0UBlk+YjKbwRKJigg==",
+            "dev": true,
+            "requires": {
+                "@types/sizzle": "*"
+            }
+        },
+        "@types/lodash": {
+            "version": "4.14.149",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
+            "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==",
+            "dev": true
+        },
         "@types/minimatch": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
             "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+            "dev": true
+        },
+        "@types/mocha": {
+            "version": "5.2.7",
+            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
+            "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==",
             "dev": true
         },
         "@types/node": {
@@ -126,6 +331,28 @@
             "requires": {
                 "@types/node": "*"
             }
+        },
+        "@types/sinon": {
+            "version": "7.5.1",
+            "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.5.1.tgz",
+            "integrity": "sha512-EZQUP3hSZQyTQRfiLqelC9NMWd1kqLcmQE0dMiklxBkgi84T+cHOhnKpgk4NnOWpGX863yE6+IaGnOXUNFqDnQ==",
+            "dev": true
+        },
+        "@types/sinon-chai": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.3.tgz",
+            "integrity": "sha512-TOUFS6vqS0PVL1I8NGVSNcFaNJtFoyZPXZ5zur+qlhDfOmQECZZM4H4kKgca6O8L+QceX/ymODZASfUfn+y4yQ==",
+            "dev": true,
+            "requires": {
+                "@types/chai": "*",
+                "@types/sinon": "*"
+            }
+        },
+        "@types/sizzle": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.2.tgz",
+            "integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==",
+            "dev": true
         },
         "@types/yauzl": {
             "version": "2.9.1",
@@ -219,6 +446,12 @@
                 "color-convert": "^1.9.0"
             }
         },
+        "any-observable": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
+            "integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==",
+            "dev": true
+        },
         "anymatch": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
@@ -228,6 +461,12 @@
                 "normalize-path": "^3.0.0",
                 "picomatch": "^2.0.4"
             }
+        },
+        "arch": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.1.tgz",
+            "integrity": "sha512-BLM56aPo9vLLFVa8+/+pJLnrZ7QGGTVHWsCwieAWT9o9K8UeGaQbzZbGoabWLOo2ksBCztoXdqBZBplqLDDCSg==",
+            "dev": true
         },
         "argparse": {
             "version": "1.0.10",
@@ -293,6 +532,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
             "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+            "dev": true
+        },
+        "async": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+            "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
             "dev": true
         },
         "async-limiter": {
@@ -387,6 +632,12 @@
             "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
             "dev": true
         },
+        "buffer-from": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+            "dev": true
+        },
         "builtin-modules": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.1.0.tgz",
@@ -397,6 +648,12 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
             "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
+            "dev": true
+        },
+        "cachedir": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.3.0.tgz",
+            "integrity": "sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==",
             "dev": true
         },
         "callsites": {
@@ -451,6 +708,12 @@
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
             "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+            "dev": true
+        },
+        "check-more-types": {
+            "version": "2.24.0",
+            "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
+            "integrity": "sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA=",
             "dev": true
         },
         "chokidar": {
@@ -518,6 +781,103 @@
             "integrity": "sha512-Xs2Hf2nzrvJMFKimOR7YR0QwZ8fc0u98kdtwN1eNAZzNQgH3vK2pXzff6GJtKh7S5hoJ87ECiAiZFS2fb5Ii2w==",
             "dev": true
         },
+        "cli-table3": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
+            "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
+            "dev": true,
+            "requires": {
+                "colors": "^1.1.2",
+                "object-assign": "^4.1.0",
+                "string-width": "^2.1.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "cli-truncate": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
+            "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+            "dev": true,
+            "requires": {
+                "slice-ansi": "0.0.4",
+                "string-width": "^1.0.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                    "dev": true,
+                    "requires": {
+                        "number-is-nan": "^1.0.0"
+                    }
+                },
+                "slice-ansi": {
+                    "version": "0.0.4",
+                    "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+                    "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                    "dev": true,
+                    "requires": {
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                }
+            }
+        },
         "cli-width": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
@@ -576,6 +936,12 @@
             "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
             "dev": true
         },
+        "code-point-at": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+            "dev": true
+        },
         "color-convert": {
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -591,6 +957,13 @@
             "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
             "dev": true
         },
+        "colors": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+            "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+            "dev": true,
+            "optional": true
+        },
         "combined-stream": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -599,6 +972,18 @@
             "requires": {
                 "delayed-stream": "~1.0.0"
             }
+        },
+        "commander": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.0.tgz",
+            "integrity": "sha512-NIQrwvv9V39FHgGFm36+U9SMQzbiHvU79k+iADraJTpmrFFfx7Ds0IvDoAdZsDrknlkRk14OYoWXb57uTh7/sw==",
+            "dev": true
+        },
+        "common-tags": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
+            "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
+            "dev": true
         },
         "compare-versions": {
             "version": "3.6.0",
@@ -611,6 +996,18 @@
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
             "dev": true
+        },
+        "concat-stream": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+            "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+            "dev": true,
+            "requires": {
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
+            }
         },
         "console-clear": {
             "version": "1.1.1",
@@ -650,6 +1047,148 @@
                 "which": "^1.2.9"
             }
         },
+        "cypress": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/cypress/-/cypress-4.5.0.tgz",
+            "integrity": "sha512-2A4g5FW5d2fHzq8HKUGAMVTnW6P8nlWYQALiCoGN4bqBLvgwhYM/oG9oKc2CS6LnvgHFiKivKzpm9sfk3uU3zQ==",
+            "dev": true,
+            "requires": {
+                "@cypress/listr-verbose-renderer": "0.4.1",
+                "@cypress/request": "2.88.5",
+                "@cypress/xvfb": "1.2.4",
+                "@types/blob-util": "1.3.3",
+                "@types/bluebird": "3.5.29",
+                "@types/chai": "4.2.7",
+                "@types/chai-jquery": "1.1.40",
+                "@types/jquery": "3.3.31",
+                "@types/lodash": "4.14.149",
+                "@types/minimatch": "3.0.3",
+                "@types/mocha": "5.2.7",
+                "@types/sinon": "7.5.1",
+                "@types/sinon-chai": "3.2.3",
+                "@types/sizzle": "2.3.2",
+                "arch": "2.1.1",
+                "bluebird": "3.7.2",
+                "cachedir": "2.3.0",
+                "chalk": "2.4.2",
+                "check-more-types": "2.24.0",
+                "cli-table3": "0.5.1",
+                "commander": "4.1.0",
+                "common-tags": "1.8.0",
+                "debug": "4.1.1",
+                "eventemitter2": "4.1.2",
+                "execa": "1.0.0",
+                "executable": "4.1.1",
+                "extract-zip": "1.7.0",
+                "fs-extra": "8.1.0",
+                "getos": "3.1.4",
+                "is-ci": "2.0.0",
+                "is-installed-globally": "0.1.0",
+                "lazy-ass": "1.6.0",
+                "listr": "0.14.3",
+                "lodash": "4.17.15",
+                "log-symbols": "3.0.0",
+                "minimist": "1.2.5",
+                "moment": "2.24.0",
+                "ospath": "1.2.2",
+                "pretty-bytes": "5.3.0",
+                "ramda": "0.26.1",
+                "request-progress": "3.0.0",
+                "supports-color": "7.1.0",
+                "tmp": "0.1.0",
+                "untildify": "4.0.0",
+                "url": "0.11.0",
+                "yauzl": "2.10.0"
+            },
+            "dependencies": {
+                "extract-zip": {
+                    "version": "1.7.0",
+                    "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
+                    "integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
+                    "dev": true,
+                    "requires": {
+                        "concat-stream": "^1.6.2",
+                        "debug": "^2.6.9",
+                        "mkdirp": "^0.5.4",
+                        "yauzl": "^2.10.0"
+                    },
+                    "dependencies": {
+                        "debug": {
+                            "version": "2.6.9",
+                            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                            "dev": true,
+                            "requires": {
+                                "ms": "2.0.0"
+                            }
+                        }
+                    }
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "log-symbols": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+                    "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.4.2"
+                    }
+                },
+                "minimist": {
+                    "version": "1.2.5",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+                    "dev": true
+                },
+                "mkdirp": {
+                    "version": "0.5.5",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+                    "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+                    "dev": true,
+                    "requires": {
+                        "minimist": "^1.2.5"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                },
+                "tmp": {
+                    "version": "0.1.0",
+                    "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
+                    "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+                    "dev": true,
+                    "requires": {
+                        "rimraf": "^2.6.3"
+                    }
+                }
+            }
+        },
+        "cypress-svelte-unit-test": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/cypress-svelte-unit-test/-/cypress-svelte-unit-test-3.0.0.tgz",
+            "integrity": "sha512-PGNty20bvWgkvHh5bpiIFXM7DmzGP61dXK7aYWpMdcsqkilFDTYY219fZJAGR6YguTSVvYEWGtsl2N204Kl29w==",
+            "dev": true,
+            "requires": {
+                "@bahmutov/cy-rollup": "2.0.0"
+            }
+        },
         "dashdash": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -663,6 +1202,12 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-1.2.0.tgz",
             "integrity": "sha512-vKQ9DTQPN1FLYiiEEOQ6IBGFqvjCa5rSK3cWMy/Nespm5d/x3dGFT9UBZnkLxCwua/IXBi2TYnwTEpsOvhC4UQ==",
+            "dev": true
+        },
+        "date-fns": {
+            "version": "1.30.1",
+            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+            "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
             "dev": true
         },
         "debug": {
@@ -859,6 +1404,12 @@
             "version": "2.7.4",
             "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.4.tgz",
             "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==",
+            "dev": true
+        },
+        "elegant-spinner": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+            "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
             "dev": true
         },
         "emoji-regex": {
@@ -1129,6 +1680,53 @@
             "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
             "dev": true
         },
+        "eventemitter2": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-4.1.2.tgz",
+            "integrity": "sha1-DhqEd6+CGm7zmVsxG/dMI6UkfxU=",
+            "dev": true
+        },
+        "execa": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+            "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+            "dev": true,
+            "requires": {
+                "cross-spawn": "^6.0.0",
+                "get-stream": "^4.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
+            },
+            "dependencies": {
+                "get-stream": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+                    "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+                    "dev": true,
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "executable": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/executable/-/executable-4.1.1.tgz",
+            "integrity": "sha512-8iA79xD3uAch729dUG8xaaBBFGaEa0wdD2VkYLFHwlqosEj/jT66AzcreRDSgV7ehnNLBW2WR5jIXwGKjVdTLg==",
+            "dev": true,
+            "requires": {
+                "pify": "^2.2.0"
+            }
+        },
+        "exit-hook": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+            "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+            "dev": true
+        },
         "extend": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -1396,6 +1994,17 @@
                 "mime-types": "^2.1.12"
             }
         },
+        "fs-extra": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+            }
+        },
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1504,6 +2113,15 @@
                 }
             }
         },
+        "getos": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/getos/-/getos-3.1.4.tgz",
+            "integrity": "sha512-UORPzguEB/7UG5hqiZai8f0vQ7hzynMQyJLxStoQ8dPGAcmgsfXOPA4iE/fGtweHYkK+z4zc9V0g+CIFRf5HYw==",
+            "dev": true,
+            "requires": {
+                "async": "^3.1.0"
+            }
+        },
         "getpass": {
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -1534,6 +2152,15 @@
             "dev": true,
             "requires": {
                 "is-glob": "^4.0.1"
+            }
+        },
+        "global-dirs": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+            "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+            "dev": true,
+            "requires": {
+                "ini": "^1.3.4"
             }
         },
         "globals": {
@@ -1615,6 +2242,23 @@
                 "function-bind": "^1.1.1"
             }
         },
+        "has-ansi": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "^2.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                }
+            }
+        },
         "has-flag": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -1633,6 +2277,11 @@
             "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
             "dev": true,
             "optional": true
+        },
+        "highlight.js": {
+            "version": "10.0.2",
+            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.0.2.tgz",
+            "integrity": "sha512-2gMT2MHU6/2OjAlnaOE2LFdr9dwviDN3Q2lSw7Ois3/5uTtahbgYTkr4EPoY828ps+2eQWiixPTF8+phU6Ofkg=="
         },
         "hosted-git-info": {
             "version": "2.7.1",
@@ -1847,6 +2496,12 @@
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true
         },
+        "ini": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+            "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+            "dev": true
+        },
         "inquirer": {
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.1.tgz",
@@ -1908,6 +2563,15 @@
             "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
             "dev": true
         },
+        "is-ci": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+            "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+            "dev": true,
+            "requires": {
+                "ci-info": "^2.0.0"
+            }
+        },
         "is-date-object": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
@@ -1935,6 +2599,27 @@
                 "is-extglob": "^2.1.1"
             }
         },
+        "is-installed-globally": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+            "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+            "dev": true,
+            "requires": {
+                "global-dirs": "^0.1.0",
+                "is-path-inside": "^1.0.0"
+            },
+            "dependencies": {
+                "is-path-inside": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+                    "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+                    "dev": true,
+                    "requires": {
+                        "path-is-inside": "^1.0.1"
+                    }
+                }
+            }
+        },
         "is-interactive": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
@@ -1952,6 +2637,15 @@
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
             "dev": true
+        },
+        "is-observable": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
+            "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
+            "dev": true,
+            "requires": {
+                "symbol-observable": "^1.1.0"
+            }
         },
         "is-path-cwd": {
             "version": "2.2.0",
@@ -1988,6 +2682,12 @@
             "requires": {
                 "has": "^1.0.1"
             }
+        },
+        "is-stream": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+            "dev": true
         },
         "is-symbol": {
             "version": "1.0.2",
@@ -2091,6 +2791,15 @@
             "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
             "dev": true
         },
+        "jsonfile": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
         "jsonify": {
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
@@ -2115,6 +2824,12 @@
             "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
             "dev": true
         },
+        "lazy-ass": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
+            "integrity": "sha1-eZllXoZGwX8In90YfRUNMyTVRRM=",
+            "dev": true
+        },
         "levn": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -2130,6 +2845,177 @@
             "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
             "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
             "dev": true
+        },
+        "listr": {
+            "version": "0.14.3",
+            "resolved": "https://registry.npmjs.org/listr/-/listr-0.14.3.tgz",
+            "integrity": "sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==",
+            "dev": true,
+            "requires": {
+                "@samverschueren/stream-to-observable": "^0.3.0",
+                "is-observable": "^1.1.0",
+                "is-promise": "^2.1.0",
+                "is-stream": "^1.1.0",
+                "listr-silent-renderer": "^1.1.1",
+                "listr-update-renderer": "^0.5.0",
+                "listr-verbose-renderer": "^0.5.0",
+                "p-map": "^2.0.0",
+                "rxjs": "^6.3.3"
+            },
+            "dependencies": {
+                "p-map": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+                    "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+                    "dev": true
+                }
+            }
+        },
+        "listr-silent-renderer": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+            "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
+            "dev": true
+        },
+        "listr-update-renderer": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
+            "integrity": "sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==",
+            "dev": true,
+            "requires": {
+                "chalk": "^1.1.3",
+                "cli-truncate": "^0.2.1",
+                "elegant-spinner": "^1.0.1",
+                "figures": "^1.7.0",
+                "indent-string": "^3.0.0",
+                "log-symbols": "^1.0.2",
+                "log-update": "^2.3.0",
+                "strip-ansi": "^3.0.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
+                    }
+                },
+                "figures": {
+                    "version": "1.7.0",
+                    "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+                    "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+                    "dev": true,
+                    "requires": {
+                        "escape-string-regexp": "^1.0.5",
+                        "object-assign": "^4.1.0"
+                    }
+                },
+                "indent-string": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+                    "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+                    "dev": true
+                },
+                "log-symbols": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+                    "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^1.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                }
+            }
+        },
+        "listr-verbose-renderer": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
+            "integrity": "sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.4.1",
+                "cli-cursor": "^2.1.0",
+                "date-fns": "^1.27.2",
+                "figures": "^2.0.0"
+            },
+            "dependencies": {
+                "cli-cursor": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+                    "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+                    "dev": true,
+                    "requires": {
+                        "restore-cursor": "^2.0.0"
+                    }
+                },
+                "figures": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+                    "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+                    "dev": true,
+                    "requires": {
+                        "escape-string-regexp": "^1.0.5"
+                    }
+                },
+                "mimic-fn": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+                    "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+                    "dev": true
+                },
+                "onetime": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+                    "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+                    "dev": true,
+                    "requires": {
+                        "mimic-fn": "^1.0.0"
+                    }
+                },
+                "restore-cursor": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+                    "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+                    "dev": true,
+                    "requires": {
+                        "onetime": "^2.0.0",
+                        "signal-exit": "^3.0.2"
+                    }
+                }
+            }
         },
         "livereload": {
             "version": "0.9.1",
@@ -2282,6 +3168,12 @@
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
             "dev": true
         },
+        "lodash.once": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+            "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
+            "dev": true
+        },
         "log-symbols": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
@@ -2290,6 +3182,100 @@
             "optional": true,
             "requires": {
                 "chalk": "^2.0.1"
+            }
+        },
+        "log-update": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",
+            "integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
+            "dev": true,
+            "requires": {
+                "ansi-escapes": "^3.0.0",
+                "cli-cursor": "^2.0.0",
+                "wrap-ansi": "^3.0.1"
+            },
+            "dependencies": {
+                "ansi-escapes": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+                    "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+                    "dev": true
+                },
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "cli-cursor": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+                    "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+                    "dev": true,
+                    "requires": {
+                        "restore-cursor": "^2.0.0"
+                    }
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
+                "mimic-fn": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+                    "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+                    "dev": true
+                },
+                "onetime": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+                    "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+                    "dev": true,
+                    "requires": {
+                        "mimic-fn": "^1.0.0"
+                    }
+                },
+                "restore-cursor": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+                    "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+                    "dev": true,
+                    "requires": {
+                        "onetime": "^2.0.0",
+                        "signal-exit": "^3.0.2"
+                    }
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                },
+                "wrap-ansi": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
+                    "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^2.1.1",
+                        "strip-ansi": "^4.0.0"
+                    }
+                }
             }
         },
         "lru-cache": {
@@ -2309,6 +3295,11 @@
             "requires": {
                 "sourcemap-codec": "^1.4.4"
             }
+        },
+        "marked": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-1.0.0.tgz",
+            "integrity": "sha512-Wo+L1pWTVibfrSr+TTtMuiMfNzmZWiOPeO7rZsQUY5bgsxpHesBEcIWJloWVTFnrMXnf/TL30eTFSGJddmQAng=="
         },
         "memorystream": {
             "version": "0.3.1",
@@ -2517,6 +3508,12 @@
                 }
             }
         },
+        "moment": {
+            "version": "2.24.0",
+            "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+            "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
+            "dev": true
+        },
         "mri": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
@@ -2689,10 +3686,31 @@
                 }
             }
         },
+        "npm-run-path": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+            "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+            "dev": true,
+            "requires": {
+                "path-key": "^2.0.0"
+            }
+        },
+        "number-is-nan": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+            "dev": true
+        },
         "oauth-sign": {
             "version": "0.9.0",
             "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
             "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+            "dev": true
+        },
+        "object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
             "dev": true
         },
         "object-inspect": {
@@ -2976,6 +3994,18 @@
             "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
             "dev": true
         },
+        "ospath": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/ospath/-/ospath-1.2.2.tgz",
+            "integrity": "sha1-EnZjl3Sj+O8lcvf+QoDg6kVQwHs=",
+            "dev": true
+        },
+        "p-finally": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+            "dev": true
+        },
         "p-limit": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
@@ -3071,6 +4101,12 @@
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
             "dev": true
         },
+        "path-is-inside": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+            "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+            "dev": true
+        },
         "path-key": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
@@ -3113,6 +4149,12 @@
             "integrity": "sha512-9CT4NFlDcosssyg8KVFltgokyKZIFjoBxw8CTGy+5F38Y1eQWrt8tRayiUOXE+zVKQnYu5BR8JjCtvK3BcnBhg==",
             "dev": true
         },
+        "pify": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+            "dev": true
+        },
         "pkg-dir": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -3151,6 +4193,12 @@
             "requires": {
                 "fast-diff": "^1.1.2"
             }
+        },
+        "pretty-bytes": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
+            "integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg==",
+            "dev": true
         },
         "process-nextick-args": {
             "version": "2.0.1",
@@ -3212,6 +4260,18 @@
             "version": "6.5.2",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
             "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+            "dev": true
+        },
+        "querystring": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+            "dev": true
+        },
+        "ramda": {
+            "version": "0.26.1",
+            "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
+            "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==",
             "dev": true
         },
         "raw-body": {
@@ -3305,6 +4365,15 @@
                 "tough-cookie": "~2.5.0",
                 "tunnel-agent": "^0.6.0",
                 "uuid": "^3.3.2"
+            }
+        },
+        "request-progress": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
+            "integrity": "sha1-TKdUCBx/7GP1BeT6qCWqBs1mnb4=",
+            "dev": true,
+            "requires": {
+                "throttleit": "^1.0.0"
             }
         },
         "request-promise": {
@@ -4061,6 +5130,12 @@
             "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
             "dev": true
         },
+        "strip-eof": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+            "dev": true
+        },
         "strip-json-comments": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
@@ -4080,6 +5155,12 @@
             "version": "3.22.2",
             "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.22.2.tgz",
             "integrity": "sha512-DxumO0+vvHA6NSc2jtVty08I8lFI43q8P2zX6JxZL8J1kqK5NVjad6TRM/twhnWXC+QScnwkZ15O6X1aTsEKTA==",
+            "dev": true
+        },
+        "symbol-observable": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+            "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
             "dev": true
         },
         "table": {
@@ -4144,6 +5225,12 @@
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
             "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+            "dev": true
+        },
+        "throttleit": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
+            "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
             "dev": true
         },
         "through": {
@@ -4234,10 +5321,28 @@
             "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
             "dev": true
         },
+        "typedarray": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+            "dev": true
+        },
+        "universalify": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+            "dev": true
+        },
         "unpipe": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
             "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+            "dev": true
+        },
+        "untildify": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+            "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
             "dev": true
         },
         "uri-js": {
@@ -4247,6 +5352,24 @@
             "dev": true,
             "requires": {
                 "punycode": "^2.1.0"
+            }
+        },
+        "url": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+            "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+            "dev": true,
+            "requires": {
+                "punycode": "1.3.2",
+                "querystring": "0.2.0"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "1.3.2",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+                    "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+                    "dev": true
+                }
             }
         },
         "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   },
   "devDependencies": {
     "chromedriver": "^81.0.0",
+    "cypress": "4.5.0",
+    "cypress-svelte-unit-test": "3.0.0",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-html": "^6.0.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,19 +6,19 @@ import livereload from 'rollup-plugin-livereload'
 const production = !process.env.ROLLUP_WATCH
 
 export default {
-    input: 'src/test.js',
-    output: {
-        file: `public/components.js`,
-        format: 'iife',
-        name: 'components',
-    },
-    plugins: [
-        svelte({
-            include: 'src/**/*.svelte',
-            dev: true,
-        }),
-        resolve(),
-        commonjs(),
-        !production && livereload('public'),
-    ],
+  input: 'src/test.js',
+  output: {
+    file: `public/components.js`,
+    format: 'iife',
+    name: 'components',
+  },
+  plugins: [
+    svelte({
+      include: 'src/**/*.svelte',
+      dev: true,
+    }),
+    resolve(),
+    commonjs(),
+    !production && livereload('public'),
+  ],
 }

--- a/src/Code.spec.js
+++ b/src/Code.spec.js
@@ -1,0 +1,15 @@
+import Code from './Code.svelte'
+import { mount } from 'cypress-svelte-unit-test'
+
+describe('Code', () => {
+  it('has syntax highlighting', () => {
+    mount(Code, {
+      props: {
+        lang: 'js',
+        code: '// this is a component test\n' + 'const cy = "Cypress"',
+      },
+    })
+    cy.contains('.hljs-comment', '// this is a component test')
+    cy.contains('.hljs-keyword', 'const')
+  })
+})

--- a/src/Code.svelte
+++ b/src/Code.svelte
@@ -1,12 +1,12 @@
 <script>
-    export let code
-    export let lang
+  export let code
+  export let lang
 
-    import marked from 'marked'
-    import hljs from 'highlight.js'
+  import marked from 'marked'
+  import hljs from 'highlight.js'
 
-    const { value: highlighted } = hljs.highlight(lang, code)
-    $: code = `<pre class='language-javascriptreact'><code>${highlighted}</code></pre>`
+  const { value: highlighted } = hljs.highlight(lang, code)
+  $: code = `<pre class='language-javascriptreact'><code>${highlighted}</code></pre>`
 </script>
 
 {@html code}

--- a/src/Notion.spec.js
+++ b/src/Notion.spec.js
@@ -1,0 +1,49 @@
+import Notion from './Notion.svelte'
+import { mount } from 'cypress-svelte-unit-test'
+
+describe('Notion', () => {
+  it('renders blocks', () => {
+    // we could move this object into a fixture or import from separate file
+    const blocks = [
+      {
+        type: 'header',
+        properties: {
+          title: [['Notion test']],
+        },
+      },
+      {
+        type: 'page',
+        properties: {
+          title: [['Page']],
+        },
+      },
+      {
+        type: 'text',
+        properties: {
+          title: [['This is a Cypress component test']],
+        },
+      },
+      {
+        type: 'divider',
+      },
+      {
+        type: 'code',
+        properties: {
+          title: [['some code here // plus comment']],
+          language: [['javascript']],
+        },
+      },
+    ]
+    mount(
+      Notion,
+      {
+        props: {
+          blocks,
+        },
+      },
+      {
+        cssFile: 'public/global.css',
+      },
+    )
+  })
+})

--- a/src/Notion.svelte
+++ b/src/Notion.svelte
@@ -1,28 +1,25 @@
 <script>
-    import Code from './Code.svelte'
-    export let blocks
+  import Code from './Code.svelte'
+  export let blocks
 </script>
 
-{#each blocks as block}
-    {#if block.type === 'header'}
-        <h1>{block.properties.title[0][0]}</h1>
-    {:else if block.type === 'page'}
-        <h2>{block.properties.title[0][0]}</h2>
-    {:else if block.type === 'sub_header'}
-        <h2>{block.properties.title[0][0]}</h2>
-    {:else if block.type === 'sub_sub_header'}
-        <h3>{block.properties.title[0][0]}</h3>
-    {:else if block.type === 'text'}
-        {#if block.properties}
-            <p>{block.properties.title[0][0]}</p>
-        {:else}
-            <br />
-        {/if}
-    {:else if block.type === 'divider'}
-        <hr />
-    {:else if block.type === 'code'}
-        <Code
-            code={block.properties.title[0][0]}
-            lang={block.properties.language[0][0]} />
-    {/if}
-{/each}
+{#each                                         blocks as block} {#if block.type === 'header'}
+<h1>{block.properties.title[0][0]}</h1>
+{:else if block.type === 'page'}
+<h2>{block.properties.title[0][0]}</h2>
+{:else if block.type === 'sub_header'}
+<h2>{block.properties.title[0][0]}</h2>
+{:else if block.type === 'sub_sub_header'}
+<h3>{block.properties.title[0][0]}</h3>
+{:else if block.type === 'text'} {#if block.properties}
+<p>{block.properties.title[0][0]}</p>
+{:else}
+<br />
+{/if} {:else if block.type === 'divider'}
+<hr />
+{:else if block.type === 'code'}
+<code
+  code="{block.properties.title[0][0]}"
+  lang="{block.properties.language[0][0]}"
+/>
+{/if} {/each}

--- a/src/fetchNotion.js
+++ b/src/fetchNotion.js
@@ -1,15 +1,15 @@
 const NOTION_API = 'https://notion-api.splitbee.io/v1/page/'
 
 export async function fetchNotion({ id, context, config }) {
-    let res
-    if (context) {
-        res = await context.fetch(NOTION_API + id)
-    }
-    const post = await res.json()
+  let res
+  if (context) {
+    res = await context.fetch(NOTION_API + id)
+  }
+  const post = await res.json()
 
-    const objectArray = Object.entries(post)
-    const blocks = objectArray.map(([key, value]) => {
-        return value.value
-    })
-    return blocks
+  const objectArray = Object.entries(post)
+  const blocks = objectArray.map(([key, value]) => {
+    return value.value
+  })
+  return blocks
 }


### PR DESCRIPTION
Tests are using Cypress + https://github.com/bahmutov/cypress-svelte-unit-test

Example
```js
import Code from './Code.svelte'
import { mount } from 'cypress-svelte-unit-test'

describe('Code', () => {
  it('has syntax highlighting', () => {
    mount(Code, {
      props: {
        lang: 'js',
        code: '// this is a component test\n' + 'const cy = "Cypress"',
      },
    })
    cy.contains('.hljs-comment', '// this is a component test')
    cy.contains('.hljs-keyword', 'const')
  })
})
```

<img width="682" alt="Screen Shot 2020-05-08 at 5 57 50 PM" src="https://user-images.githubusercontent.com/2212006/81453463-966b0600-9157-11ea-8c34-4118a0589ee6.png">

Similarly, the Notion component test

<img width="674" alt="Screen Shot 2020-05-08 at 6 06 27 PM" src="https://user-images.githubusercontent.com/2212006/81453495-a7b41280-9157-11ea-94a9-ef652e69a70d.png">

PS: hmm, seems Prettier and ESLint are fighting over style issues, as I was trying to fix one, the other one was breaking