### PR TITLE
Add <pre> and <code> for Code Block

### DIFF
--- a/src/blocks/Code.svelte
+++ b/src/blocks/Code.svelte
@@ -9,4 +9,7 @@
     $: code = `<pre class='language-javascriptreact'><code>${highlighted}</code></pre>`
 </script>
 
-{@html code}
+<pre
+  class="language-{lang}">
+    <code class="language-{lang}">{@html html}</code>
+</pre>


### PR DESCRIPTION
PrismJS requires surrounding the highlighted code with a `<pre>` and a `<code>` https://prismjs.com/#basic-usage